### PR TITLE
Change base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN cd /hamsterball/dependencies && \
     mvn package -Dmaven.test.skip=true && \
     mv target/odk-hamsterball-*.jar /odk-hamsterball-client.jar
 
-FROM openjdk:8-jdk
+FROM openjdk:8-jre-slim
 
 # Control Java heap and metaspace sizes
 ENV MIN_HEAP 256m


### PR DESCRIPTION
The base image was mistakenly set to the JDK image. This changes it to the JRE image. The JRE image has a significantly smaller footprint and we only need the JRE part. 