### PR TITLE
Use JDK 8 based Maven to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3 as compiler
+FROM maven:3-jdk-8 as compiler
 
 COPY . /web-ui
 


### PR DESCRIPTION
The maven image was recently updated to be based on JDK 14. This pull request changes the tag to stay on JDK 8.

The JDK 8 based image is still maintained and updated.