### PR TITLE
Web UI sync endpoint page

### DIFF
--- a/src/main/resources/static/css/loginlayout.css
+++ b/src/main/resources/static/css/loginlayout.css
@@ -1,19 +1,7 @@
-h1 {
-    text-align: center;
-}
-
-.container {
-	background-color: white;
-}
-
-.content {
+#login-content {
     width: 440px;
 }
 
-.navbar-static-top {
-	margin-bottom: 19px;
-}
-
-#odk-menu-icon {
-	margin-top: -18px;
+#login-title {
+	text-align: center;
 }

--- a/src/main/resources/static/css/menulayout.css
+++ b/src/main/resources/static/css/menulayout.css
@@ -17,11 +17,11 @@
 }
 
 
-
 #odk-menu-icon {
-	margin-top: -6px;
+	margin-top: -18px;
 }
 
 #odk-sign-out {
 	margin-top: 8px;
 }
+

--- a/src/main/resources/static/css/whoami.css
+++ b/src/main/resources/static/css/whoami.css
@@ -1,0 +1,25 @@
+.section-container {
+    width:400px;
+    margin: 50px;
+}
+
+.row {
+    border-bottom: 1px solid gray;
+    height: 50px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.row-header {
+    color:gray;
+}
+
+.row-name {
+    width: 120px;
+}
+
+#tables-container {
+    display: flex;
+    flex-direction: row;
+}

--- a/src/main/resources/templates/login_layout.html
+++ b/src/main/resources/templates/login_layout.html
@@ -5,6 +5,7 @@
 	layout:decorate="~{root_layout}">
 
 <head>
+	<link rel="stylesheet" th:href="@{/css/menulayout.css}">
 	<link rel="stylesheet" th:href="@{/css/loginlayout.css}">
 </head>
 
@@ -18,8 +19,8 @@
 					height="64"></a>
 			</div>
 		</nav>
-		<div class="container content">
-			<h1>
+		<div class="container" id="login-content">
+			<h1 id="login-title">
 				<th:block layout:fragment="title"></th:block>
 			</h1>
 

--- a/src/main/resources/templates/top_menu_layout.html
+++ b/src/main/resources/templates/top_menu_layout.html
@@ -6,7 +6,7 @@
 <!--/*@thymesVar id="tableIds" type="java.util.List<String>"*/-->
 <!--/*@thymesVar id="currentUser" type="org.opendatakit.aggregate.odktables.rest.entity.PrivilegesInfo"*/-->
 <head>
-<link rel="stylesheet" th:href="@{/css/menulayout.css}">
+	<link rel="stylesheet" th:href="@{/css/menulayout.css}">
 </head>
 
 <body>
@@ -23,8 +23,8 @@
 							class="icon-bar"></span>
 					</button>
 					<a class="navbar-brand" href="#"><img id="odk-menu-icon"
-						alt="ODK Client" th:src="@{/images/poverty_stoplight_32.png}" width="32"
-						height="32"></a>
+						alt="ODK Client" th:src="@{/images/ODKX.png}" width="64"
+						height="64"></a>
 				</div>
 				<div id="navbar" class="navbar-collapse collapse">
 					<ul class="nav navbar-nav">
@@ -53,7 +53,7 @@
 							data-toggle="dropdown" role="button" aria-haspopup="true"
 							aria-expanded="false">My Account <span class="caret"></span></a>
 							<ul class="dropdown-menu">
-								<li><a th:href="@{/whoami}">Who Am I?</a></li>
+								<li><a th:href="@{/whoami}">Account details</a></li>
 							</ul></li>
 
 					</ul>

--- a/src/main/resources/templates/whoami.html
+++ b/src/main/resources/templates/whoami.html
@@ -8,18 +8,53 @@
 <!--/*@thymesVar id="fullName" type="java.lang.String"*/-->
 <!--/*@thymesVar id="officeId" type="java.lang.String"*/-->
 <!--/*@thymesVar id="roleDescriptions" type="java.util.Map<String, String>"*/-->
+	<head>
+		<link rel="stylesheet" th:href="@{/css/whoami.css}">
+	</head>
 
-<th:block layout:fragment="title">Who Am I?</th:block>
+<th:block layout:fragment="title">Sync-Endpoint</th:block>
 <body>
 	<section layout:fragment="content">
-		<p th:text="'Username: ' + ${username}"></p>
-		<p th:text="'Full name: ' + ${fullName}"></p>
-		<p th:if="${officeId != null}" th:text="'Default group: ' + ${officeId}"></p>
-
-		<h2>Groups and Roles</h2>
-		<ul th:each="role: ${roleDescriptions}">
-			<li th:text="${role.key}">Role Name</li>
-		</ul>
+		<div id = "tables-container">
+			<div class="section-container">
+				<div class = "row">
+					<h2 class="row-header">Account details</h2>
+				</div>
+				<div class = "row">
+					<p class="row-name">Username:</p>
+					<b th:text="${username}"></b>
+				</div>
+				<div class = "row">
+					<p class="row-name">Full name:</p>
+					<b th:text="${fullName}"></b>
+				</div>
+				<div class = "row">
+					<th:block th:if="${officeId != null}">
+						<p class="row-name">Default group:</p>
+						<b th:text="${officeId}"></b>
+					</th:block>
+				</div>
+				<th:block th:each="role: ${roleDescriptions}">
+					<div class = "row">
+						<p class="row-name">Group/role:</p>
+						<b th:text="${role.key}"></b>
+					</div>
+				</th:block>
+			</div>
+			<br>
+			<br>
+			<div class="section-container">
+				<div class = "row">
+					<h2 class="row-header">Form tables</h2>
+				</div>
+				<th:block th:each="topTid: ${tableIds}">
+					<div class = "row">
+						<b><a th:text="${topTid}"
+							th:href="@{|/tables/manifest/${topTid}|}"></a></b>
+					</div>
+				</th:block>
+			</div>
+		</div>
 	</section>
 </body>
 </html>


### PR DESCRIPTION
Adressed issue #275, improving the webUI for the sync-endpoint landing page.

![odkx](https://user-images.githubusercontent.com/63220688/128264217-db9036c9-660c-4e45-8d7b-55e2c498f7fd.PNG)

I made changes to HTML and css files relating to top_menu_layout and whoami.

Minor unresolved problems:

The file for the landing page is still called whoami.html and whoami.css, I did not change the name of the file because I am not sure what calls whoami.html after the login is successful.

The groups and roles are simply called group/role, it is probably too complicated to separate them into groups and roles